### PR TITLE
Tech debt/tec 54 introduce default tenant in backend test framework to replace legacy tenant id usage

### DIFF
--- a/test/__tests__/builders/baseBuilder.js
+++ b/test/__tests__/builders/baseBuilder.js
@@ -3,7 +3,7 @@ import db from '../../setup/db';
 export default class BaseBuilder {
   constructor(defaultValues = true, hasTenant = true) {
     this.useDefault = defaultValues;
-    this.properties = hasTenant ? { tenant: db.tenantId } : {};
+    this.properties = hasTenant ? { tenant: db.defaultTenant._id } : {};
   }
 
   async buildDefault() {

--- a/test/__tests__/builders/epicBuilder.js
+++ b/test/__tests__/builders/epicBuilder.js
@@ -78,7 +78,7 @@ export default class EpicBuilder extends BaseBuilder {
     return {
       title: 'Epic Title',
       project: project._id,
-      tenant: db.tenantId,
+      tenant: db.defaultTenant._id,
     };
   }
 

--- a/test/__tests__/builders/labelBuilder.js
+++ b/test/__tests__/builders/labelBuilder.js
@@ -26,7 +26,7 @@ export default class LabelBuilder extends BaseBuilder {
     return {
       name: 'Default Label',
       slug: 'default-label',
-      tenant: db.tenantId,
+      tenant: db.defaultTenant._id,
     };
   }
 

--- a/test/__tests__/builders/sprintBuilder.js
+++ b/test/__tests__/builders/sprintBuilder.js
@@ -48,7 +48,7 @@ export default class SprintBuilder extends BaseBuilder {
     return {
       name: 'Sprint Title',
       project: project._id,
-      tenant: db.tenantId,
+      tenant: db.defaultTenant._id,
     };
   }
 

--- a/test/__tests__/builders/statusBuilder.js
+++ b/test/__tests__/builders/statusBuilder.js
@@ -32,7 +32,7 @@ export default class StatusBuilder extends BaseBuilder {
     return {
       name: 'To Do',
       slug: 'to-do',
-      tenant: db.tenantId,
+      tenant: db.defaultTenant._id,
       isDefault: true,
     };
   }
@@ -56,7 +56,7 @@ export default class StatusBuilder extends BaseBuilder {
     const saved = [];
 
     for (const status of DEFAULT_STATUS) {
-      const existing = await StatusModel.findOne({ slug: status.slug, tenant: db.tenantId });
+      const existing = await StatusModel.findOne({ slug: status.slug, tenant: db.defaultTenant._id });
       if (existing) {
         saved.push(existing);
       } else {
@@ -64,7 +64,7 @@ export default class StatusBuilder extends BaseBuilder {
           .withName(status.name)
           .withSlug(status.slug)
           .withIsDefault(status.isDefault)
-          .withTenant(db.tenantId)
+          .withTenant(db.defaultTenant._id)
           .save();
         saved.push(newStatus);
       }

--- a/test/__tests__/login.test.js
+++ b/test/__tests__/login.test.js
@@ -2,31 +2,19 @@ import request from 'supertest';
 import app from '../setup/app';
 import db from '../setup/db';
 import UserBuilder from './builders/userBuilder';
-import TenantBuilder from './builders/tenantBuilder';
 
 describe('Login API tests', () => {
-  let tenant;
-
-  beforeAll(async () => {
-    tenant = await new TenantBuilder()
-      .withOrigin('http://test.com')
-      .withPlan('Free')
-      .withOwner(db.defaultUser.id)
-      .withActive(true)
-      .save();
-  });
-
   it('should login with matched data provided', async () => {
     const user = await new UserBuilder()
       .withName('Test User')
       .withEmail('test@gmail.com')
       .withPassword('test123')
-      .withTenants([tenant.id])
+      .withTenants([db.defaultTenant.id])
       .save();
 
     const res = await request(app.application)
       .post('/api/v2/login')
-      .set('Origin', tenant.origin)
+      .set('Origin', db.defaultTenant.origin)
       .send({ email: user.email, password: 'test123' });
     expect(res.statusCode).toBe(200);
   });
@@ -35,12 +23,12 @@ describe('Login API tests', () => {
     await new UserBuilder()
       .withEmail('test@gmail.com')
       .withPassword('test123')
-      .withTenants([tenant.id])
+      .withTenants([db.defaultTenant.id])
       .save();
 
     const res = await request(app.application)
       .post('/api/v2/login')
-      .set('Origin', tenant.origin)
+      .set('Origin', db.defaultTenant.origin)
       .send({ email: 'TeST@GmAiL.COM', password: 'test123' });
     expect(res.statusCode).toBe(200);
   });

--- a/test/setup/db.js
+++ b/test/setup/db.js
@@ -1,11 +1,12 @@
 import UserBuilder from '../__tests__/builders/userBuilder';
+import TenantBuilder from '../__tests__/builders/tenantBuilder';
 import dbHandler from './dbHandler';
 
 let dbConnection = null;
 let tenantsConnection = null;
 let isInitialized = false;
-let tenantId = '62e333606fb0da0a12dcfe78';
 let defaultUser = null;
+let defaultTenant = null;
 
 async function connect() {
   if (!isInitialized) {
@@ -26,6 +27,9 @@ async function connect() {
 async function createDefaultData() {
   const user = await new UserBuilder().save();
   defaultUser = user;
+
+  const tenant = await new TenantBuilder().withOwner(user._id).save();
+  defaultTenant = tenant;
 }
 
 async function clearDatabase() {
@@ -44,5 +48,7 @@ export default {
   get defaultUser() {
     return defaultUser;
   },
-  tenantId,
+  get defaultTenant() {
+    return defaultTenant;
+  },
 };

--- a/test/setup/jest-setup.js
+++ b/test/setup/jest-setup.js
@@ -13,7 +13,7 @@ beforeAll(async () => {
   sinon.stub(saasMiddleware, 'saas').callsFake(function (req, res, next) {
     req.dbConnection = db.dbConnection;
     req.tenantsConnection = db.tenantsConnection;
-    req.tenantId = db.tenantId;
+    req.tenantId = db.defaultTenant._id;
     req.userId = db.defaultUser._id;
     return next();
   });


### PR DESCRIPTION
The PR added a `defaultTenant` in the jest test framework to replace legacy `tenantId` usage:
- Added a `defaultTenant`
- Replaced all `tenantId` in jest tests

All tests passed:
| origin | current |
| ------ | -------- |
| ![image](https://github.com/user-attachments/assets/f80c673c-5cb5-4fce-9694-7e59fd4f03f7) | ![image](https://github.com/user-attachments/assets/beb9a85b-9c95-4f60-8ff9-3741d5a7db55)  |